### PR TITLE
Fix memory cleanup in MainWindow

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -260,6 +260,7 @@ MainWindow::MainWindow(QWidget *parent)
 }
 
 MainWindow::~MainWindow() {
+    delete dataProcessor;
     delete ui;
 }
 


### PR DESCRIPTION
## Summary
- free `dataProcessor` inside `MainWindow` destructor to avoid leak

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684abb5ac3088328aad73f08b50f4923