### PR TITLE
Fix case of export header includes

### DIFF
--- a/exportdatatofiles.cpp
+++ b/exportdatatofiles.cpp
@@ -1,4 +1,4 @@
-#include "ExportDataToFiles.h"
+#include "exportdatatofiles.h"
 #include "dataProcessor.h"
 
 #include <QFile>

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -8,7 +8,7 @@
 #include <QDateTime>
 #include <QDebug>
 #include "ipsettingsdialog.h"
-#include "exportDataToFiles.h"
+#include "exportdatatofiles.h"
 
 MainWindow::MainWindow(QWidget *parent)
     : QMainWindow(parent)


### PR DESCRIPTION
## Summary
- use `exportdatatofiles.h` include consistently

## Testing
- `qmake -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684abb48d628832886b6d289c3d64588