### PR TITLE
Add peak-based SpO2 calculation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ cmake-build-*/
 ui_*.h
 *.exe
 *.pro.user
+Result/
+Result_Binar/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# ESP32 SpO2 Monitor
+
+This Qt application connects to an ESP32 device that streams MAX30102 sensor readings. It visualises IR, RED, BPM, temperature and calculates SpO₂ by two methods:
+
+1. **AC/DC** – continuous calculation using the last few seconds of data.
+2. **Peak Cycle** – calculation for each pulse interval.
+
+## Building
+
+Requirements: Qt 6 with Charts module, C++17 compiler.
+
+```bash
+qmake esp32_v5.pro
+make
+```
+
+Run the resulting executable and configure the ESP32 IP address if needed.
+
+Exported data is written to `Result/` and `Result_Binar/`.

--- a/dataProcessor.h
+++ b/dataProcessor.h
@@ -4,6 +4,8 @@
 #include <QLineSeries>
 #include <QValueAxis>
 #include <QVector>
+#include <QDeque>
+#include <utility>
 #include <QLabel>
 #include <QDateTime>
 #include <QObject>
@@ -32,6 +34,7 @@ public:
 
 private:
     double calculateAverage(const QVector<double>& values);
+    double calculateAverage(const QDeque<std::pair<qint64, double>>& values);
     double calculateMedian(QVector<double> values);
     QVector<double> bpmValues;
     QVector<qint64> bpmTimeStamps;
@@ -48,6 +51,7 @@ public:
                   QLineSeries* irSeries,
                   QLineSeries* tempSeries,
                   QLineSeries* spo2Series,
+                  QLineSeries* spo2PeakSeries,
                   QValueAxis* irAxisX,
                   QValueAxis* bpmAxisX,
                   QValueAxis* avgBpmAxisX,
@@ -70,6 +74,7 @@ public:
     QLineSeries* getAvgBPMSeries() const { return avgBpmSeries; }
     QLineSeries* getTempSeries() const { return tempSeries; }
     QLineSeries* getSpo2Series() const { return spo2Series; }
+    QLineSeries* getSpo2PeakSeries() const { return spo2PeakSeries; }
     // Геттер для серии пиков (QScatterSeries)
     QScatterSeries* getPeakSeries() const { return peakSeries; }
 
@@ -79,6 +84,7 @@ public:
     const QVector<QPointF>& getAllBpmData() const { return allBpmData; }
     const QVector<QPointF>& getAllAvgBpmData() const { return allAvgBpmData; }
     const QVector<QPointF>& getAllSpo2Data() const { return allSpo2Data; }
+    const QVector<QPointF>& getAllSpo2PeakData() const { return allSpo2PeakData; }
 
     const MinuteAverageCalculator* getMinuteCalculator() const { return &minuteCalculator; }
 
@@ -98,6 +104,7 @@ private:
     QLineSeries* irSeries;
     QLineSeries* tempSeries;
     QLineSeries* spo2Series;
+    QLineSeries* spo2PeakSeries;
     QLineSeries* redSeries;  // Серия для Red
 
     QVector<QPointF> allIRData;
@@ -106,6 +113,7 @@ private:
     QVector<QPointF> allBpmData;
     QVector<QPointF> allAvgBpmData;
     QVector<QPointF> allSpo2Data;
+    QVector<QPointF> allSpo2PeakData;
 
     QValueAxis* irAxisX;
     QValueAxis* bpmAxisX;
@@ -120,8 +128,11 @@ private:
     qint64 lastPeakTime;
 
     MinuteAverageCalculator minuteCalculator;
-    QVector<double> redBuffer;
-    QVector<double> irBuffer;
+    QDeque<std::pair<qint64, double>> redBuffer;
+    QDeque<std::pair<qint64, double>> irBuffer;
+    QVector<double> intervalIrValues;
+    QVector<double> intervalRedValues;
+    const int spo2WindowMs;
 
     // Для детекции пиков по окну:
     QVector<double> peakWindowValues;

--- a/esp32_v5.pro
+++ b/esp32_v5.pro
@@ -1,4 +1,3 @@
-QT       += core gui
 QT += core gui network charts
 greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
 

--- a/exportdatatofiles.cpp
+++ b/exportdatatofiles.cpp
@@ -46,9 +46,13 @@ void ExportDataToFiles::exportAllDataToText(const DataProcessor* dp, const QStri
     QString pathTemp = dir.absoluteFilePath(baseFilename + "_Temp.txt");
     saveVectorTxt(dp->getAllTempData(), startTime, pathTemp);
 
-    // 6) SpO2
+    // 6) SpO2 (AC/DC)
     QString pathSpo2 = dir.absoluteFilePath(baseFilename + "_Spo2.txt");
     saveVectorTxt(dp->getAllSpo2Data(), startTime, pathSpo2);
+
+    // 7) SpO2 by peaks
+    QString pathSpo2P = dir.absoluteFilePath(baseFilename + "_Spo2Peaks.txt");
+    saveVectorTxt(dp->getAllSpo2PeakData(), startTime, pathSpo2P);
 
     // 7) Файл с данными по BPM за 1 минуту (среднее, минимум, максимум)
     QString pathBpm1min = dir.absoluteFilePath(baseFilename + "_BPM1min.txt");
@@ -111,9 +115,13 @@ void ExportDataToFiles::exportAllDataToBinary(const DataProcessor* dp, const QSt
     QString pathTemp = dir.absoluteFilePath(baseFilename + "_Temp.bin");
     saveVectorBin(dp->getAllTempData(), startTime, pathTemp);
 
-    // 6) SpO2
+    // 6) SpO2 (AC/DC)
     QString pathSpo2 = dir.absoluteFilePath(baseFilename + "_Spo2.bin");
     saveVectorBin(dp->getAllSpo2Data(), startTime, pathSpo2);
+
+    // 7) SpO2 by peaks
+    QString pathSpo2P = dir.absoluteFilePath(baseFilename + "_Spo2Peaks.bin");
+    saveVectorBin(dp->getAllSpo2PeakData(), startTime, pathSpo2P);
 
     qDebug() << "Binary export complete, baseFilename =" << baseFilename;
 }

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -30,6 +30,9 @@ MainWindow::MainWindow(QWidget *parent)
 
     // Серия для SpO₂
     QLineSeries *bloodOxygenSaturationSeries = new QLineSeries();
+    bloodOxygenSaturationSeries->setName("SpO₂ AC/DC");
+    QLineSeries *bloodOxygenSaturationPeakSeries = new QLineSeries();
+    bloodOxygenSaturationPeakSeries->setName("SpO₂ Peaks");
 
     // Создаем оси для графиков (отображение в секундах)
     QValueAxis *axisIrX   = new QValueAxis();
@@ -47,6 +50,7 @@ MainWindow::MainWindow(QWidget *parent)
         new QLineSeries(), // IR series
         new QLineSeries(), // Temperature series
         bloodOxygenSaturationSeries, // SpO₂ series
+        bloodOxygenSaturationPeakSeries, // SpO₂ by peaks
         axisIrX, axisBpmX, axisAvgX, axisTempX, axisRedX, axisSpo2X,
         averageMinuteBpmLabel
         );
@@ -208,8 +212,13 @@ MainWindow::MainWindow(QWidget *parent)
         spo2Chart->addAxis(spo2AxisY, Qt::AlignLeft);
 
         spo2Chart->addSeries(dataProcessor->getSpo2Series());
+        spo2Chart->addSeries(dataProcessor->getSpo2PeakSeries());
+        dataProcessor->getSpo2Series()->setColor(Qt::blue);
+        dataProcessor->getSpo2PeakSeries()->setColor(Qt::darkGreen);
         dataProcessor->getSpo2Series()->attachAxis(axisSpo2XPtr);
         dataProcessor->getSpo2Series()->attachAxis(spo2AxisY);
+        dataProcessor->getSpo2PeakSeries()->attachAxis(axisSpo2XPtr);
+        dataProcessor->getSpo2PeakSeries()->attachAxis(spo2AxisY);
 
         spo2ChartView->setChart(spo2Chart);
     }


### PR DESCRIPTION
## Summary
- add README with build instructions
- ignore export result folders
- remove duplicate line in project file
- store IR/RED values in timestamp-based buffers
- implement SpO₂ calculation by peaks and continuous AC/DC method
- plot second SpO₂ series for peak calculations
- export additional SpO₂ data

## Testing
- `qmake` *(fails: command not found)*
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_684ab26a61408328a8f36d6d0c56e16d