### PR TITLE
Remove unused detectSpO2 helper

### DIFF
--- a/dataProcessor.cpp
+++ b/dataProcessor.cpp
@@ -159,11 +159,6 @@ double DataProcessor::calculateAverage(const QDeque<std::pair<qint64, double>>& 
     return sum / values.size();
 }
 
-double DataProcessor::detectSpO2(double irValue, double redValue) {
-    // Логика расчёта SpO₂ может быть реализована здесь
-    return 0.0;
-}
-
 // Сохраняем старую функцию, если понадобится (но новый алгоритм в processValues используется для пиков)
 bool DataProcessor::detectPeakImproved(double irValue, qint64 timestamp) {
     bool peakDetected = false;

--- a/dataProcessor.h
+++ b/dataProcessor.h
@@ -63,7 +63,6 @@ public:
     void processValues(qint64 timestamp, double irValue, double redValue, double tempValue);
     bool detectPeakImproved(double irValue, qint64 timestamp);
     double calculateAverage(const QVector<double>& values);
-    double detectSpO2(double irValue, double redValue);
 
     qint64 getStartTime() const { return timeStart; }
     double getElapsedTime() const { return (static_cast<double>(lastReceivedTimestamp - timeStart)) / 1000.0; }


### PR DESCRIPTION
## Summary
- drop the unused `detectSpO2` declaration and definition

## Testing
- `g++ -c dataProcessor.cpp` *(fails: QLineSeries not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bee283fb48328a10fa922ff56f29b