### PR TITLE
Implement DataProcessor destructor

### DIFF
--- a/dataProcessor.cpp
+++ b/dataProcessor.cpp
@@ -141,6 +141,29 @@ DataProcessor::DataProcessor(QLineSeries* bpmSeries,
     peakSeries->setMarkerSize(10.0);
 }
 
+DataProcessor::~DataProcessor() {
+    auto maybeDelete = [](QObject* obj) {
+        if (obj && obj->parent() == nullptr)
+            delete obj;
+    };
+
+    maybeDelete(peakSeries);
+    maybeDelete(redSeries);
+    maybeDelete(bpmSeries);
+    maybeDelete(avgBpmSeries);
+    maybeDelete(irSeries);
+    maybeDelete(tempSeries);
+    maybeDelete(spo2Series);
+    maybeDelete(spo2PeakSeries);
+
+    maybeDelete(irAxisX);
+    maybeDelete(bpmAxisX);
+    maybeDelete(avgBpmAxisX);
+    maybeDelete(tempAxisX);
+    maybeDelete(redAxisX);
+    maybeDelete(spo2AxisX);
+}
+
 double DataProcessor::calculateAverage(const QVector<double>& values) {
     if (values.isEmpty())
         return 0;

--- a/dataProcessor.h
+++ b/dataProcessor.h
@@ -60,6 +60,8 @@ public:
                   QValueAxis* spo2AxisX,
                   QLabel* avgLabel);
 
+    ~DataProcessor();
+
     void processValues(qint64 timestamp, double irValue, double redValue, double tempValue);
     bool detectPeakImproved(double irValue, qint64 timestamp);
     double calculateAverage(const QVector<double>& values);


### PR DESCRIPTION
## Summary
- declare `~DataProcessor()` in the header
- implement destructor to free dynamically allocated series and axes

## Testing
- `qmake --version` *(fails: command not found)*
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_684bee2bad5883288f3e8c0da8dbb655