### PR TITLE
Remove unused QQueue average

### DIFF
--- a/dataProcessor.h
+++ b/dataProcessor.h
@@ -34,7 +34,6 @@ public:
 
 private:
     double calculateAverage(const QVector<double>& values);
-    double calculateAverage(const QQueue<std::pair<qint64, double>>& values);
     double calculateMedian(QVector<double> values);
     QVector<double> bpmValues;
     QVector<qint64> bpmTimeStamps;


### PR DESCRIPTION
## Summary
- clean up `MinuteAverageCalculator` private API by removing unused function

## Testing
- `qmake` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bf6e3e0308328aec02b2dca59c91a